### PR TITLE
Fix: screenshots are not shown in TestDetailsV5

### DIFF
--- a/packages/dashboard/src/components/test/TestDetails/TextDetailsV5.tsx
+++ b/packages/dashboard/src/components/test/TestDetails/TextDetailsV5.tsx
@@ -27,7 +27,7 @@ const TestAttemptView = ({
   attempt: TestAttempt;
   screenshot: Partial<InstanceScreeshot>;
 }) => {
-  const [open, toggleOpen] = useSwitch();
+  const [open, toggleOpen] = useSwitch(true);
 
   return (
     <Grid>


### PR DESCRIPTION
`useSwitch` accepts a initialising argument which defaults to false. To be able to display the screenshots on the Test Details we need to provide `true`.

Fixes #154.